### PR TITLE
Update mwaa_authx.py

### DIFF
--- a/cdk/quickstart_mwaa_authx_lambda_code/mwaa_authx.py
+++ b/cdk/quickstart_mwaa_authx_lambda_code/mwaa_authx.py
@@ -53,6 +53,8 @@ def lambda_handler(event, context):
     
         if path == '/aws_mwaa/aws-console-sso':
             redirect = login(headers=headers, user_claims=user_claims)
+        elif path == '/logout/':
+            redirect = logout(headers=headers)      
         else:
             redirect = close(headers, f"Bad request: {path}, {headers}", status_code=400)
     elif path == '/logout':


### PR DESCRIPTION
Added as part of fix as issue on public repo for logout failure

*Issue #, if available:*

*Description of changes:*
if x-amzn-oidc-data header has in cookie, it never logs-out so need to force to logout when logout is clicked/requested. This happened with Okta integration. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
